### PR TITLE
Correct import of sleep in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ _sleep-promise_ resolves a promise after a specified delay.
 ## Usage async / await
 
 ```javascript
-import sleep from 'sleep-promise';
+import * as sleep from 'sleep-promise';
 
 (async () => {
     await sleep(2000);


### PR DESCRIPTION
The current documented way of importing sleep does not work as to access the default import you need (* as x) else you run into issue. If it requires() it would have been fine